### PR TITLE
fix(entities): corregir Estancia, Contrato y UniversidadCerca (BaseEntity & JPA mappings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Proyecto base para el Backend. Curso Modelos de Programación
 
 ## Enlaces de interés
-- [Jenkins](http://167.249.42.6:8081/jenkins/) 
-- [SonarQube](http://167.249.42.6:8082/sonar/) 
+- [Jenkins](http://200.69.103.29:8085/jenkins/) 
+- [SonarQube](http://200.69.103.29:8084/sonar/) 

--- a/src/main/java/co/edu/udistrital/mdp/back/entities/Contrato.java
+++ b/src/main/java/co/edu/udistrital/mdp/back/entities/Contrato.java
@@ -1,45 +1,38 @@
 package co.edu.udistrital.mdp.back.entities;
 
 import jakarta.persistence.*;
-import java.time.LocalDate;
-import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-/** Contrato 1..1 con Estancia. Este lado es el dueño y guarda la FK única. */
+import java.time.LocalDate;
+
+/**Contrato 1..1 con Estancia. Este lado es dueño y guarda la FK única.*/
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Table(name = "contrato")
-public class Contrato {
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Contrato extends BaseEntity {
 
     @Column(nullable = false, unique = true, length = 50)
     private String codigo;
 
-    @Column(nullable = false) private LocalDate fechaInicio;
-    @Column(nullable = false) private LocalDate fechaFin;
-    @Column(nullable = false) private Double montoTotal;
+    @Column(nullable = false)
+    private LocalDate fechaInicio;
 
-    @OneToOne(optional = false, fetch = FetchType.LAZY)
+    @Column(nullable = false)
+    private LocalDate fechaFin;
+
+    @Column(nullable = false)
+    private Double montoTotal;
+    
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "estancia_id", nullable = false, unique = true)
     private Estancia estancia;
-
-    public Contrato() {}
-    public Contrato(String codigo, LocalDate inicio, LocalDate fin, Double montoTotal, Estancia estancia) {
-        this.codigo = codigo; this.fechaInicio = inicio; this.fechaFin = fin; this.montoTotal = montoTotal; this.estancia = estancia;
-    }
-
-    public Long getId() { return id; }
-    public String getCodigo() { return codigo; }
-    public void setCodigo(String codigo) { this.codigo = codigo; }
-    public LocalDate getFechaInicio() { return fechaInicio; }
-    public void setFechaInicio(LocalDate fechaInicio) { this.fechaInicio = fechaInicio; }
-    public LocalDate getFechaFin() { return fechaFin; }
-    public void setFechaFin(LocalDate fechaFin) { this.fechaFin = fechaFin; }
-    public Double getMontoTotal() { return montoTotal; }
-    public void setMontoTotal(Double montoTotal) { this.montoTotal = montoTotal; }
-    public Estancia getEstancia() { return estancia; }
-    public void setEstancia(Estancia estancia) { this.estancia = estancia; }
-
-    @Override public boolean equals(Object o){ return o instanceof Contrato c && id!=null && id.equals(c.id); }
-    @Override public int hashCode(){ return Objects.hashCode(id); }
 }

--- a/src/main/java/co/edu/udistrital/mdp/back/entities/Estancia.java
+++ b/src/main/java/co/edu/udistrital/mdp/back/entities/Estancia.java
@@ -1,22 +1,22 @@
 package co.edu.udistrital.mdp.back.entities;
 
 import jakarta.persistence.*;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-/**
- * Estancia: relaciona Estudiante con Vivienda y tiene un Contrato 1..1.
- */
+/** Estancia: relaciona Estudiante con Vivienda y tiene un Contrato 1..1.*/
+@Data
+@NoArgsConstructor
 @Entity
 @Table(name = "estancia")
-public class Estancia {
+public class Estancia extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+    // Muchos registros de Estancia pueden pertenecer al mismo Estudiante
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "estudiante_id", nullable = false)
     private Estudiante estudianteArrendador;
 
+    // Muchas Estancias pueden referirse a la misma Vivienda
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "vivienda_id", nullable = false)
     private Vivienda viviendaArrendada;
@@ -24,23 +24,13 @@ public class Estancia {
     @Column(nullable = false)
     private Integer tiempoEstancia;
 
+    // Relación 1..1 inversa: el dueño está en Contrato
     @OneToOne(mappedBy = "estancia", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Contrato contrato;
 
-    public Estancia() {}
     public Estancia(Estudiante est, Vivienda viv, Integer meses) {
-        this.estudianteArrendador = est; this.viviendaArrendada = viv; this.tiempoEstancia = meses;
+        this.estudianteArrendador = est;
+        this.viviendaArrendada = viv;
+        this.tiempoEstancia = meses;
     }
-
-    public Long getId() { return id; }
-    public Estudiante getEstudianteArrendador() { return estudianteArrendador; }
-    public void setEstudianteArrendador(Estudiante e) { this.estudianteArrendador = e; }
-    public Vivienda getViviendaArrendada() { return viviendaArrendada; }
-    public void setViviendaArrendada(Vivienda v) { this.viviendaArrendada = v; }
-    public Integer getTiempoEstancia() { return tiempoEstancia; }
-    public void setTiempoEstancia(Integer t) { this.tiempoEstancia = t; }
-    public Contrato getContrato() { return contrato; }
-
-    @Override public boolean equals(Object o){ return o instanceof Estancia e && id!=null && id.equals(e.id); }
-    @Override public int hashCode(){ return Objects.hashCode(id); }
 }

--- a/src/main/java/co/edu/udistrital/mdp/back/entities/UniversidadCerca.java
+++ b/src/main/java/co/edu/udistrital/mdp/back/entities/UniversidadCerca.java
@@ -5,13 +5,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-/** Universidad cercana a la que se asocian varias Viviendas (1..N). */
+/** Universidad cercana (1..N)*/
 @Entity
 @Table(name = "universidad_cerca")
-public class UniversidadCerca {
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class UniversidadCerca extends BaseEntity {
 
     @Column(nullable = false, unique = true, length = 150)
     private String nombre;
@@ -19,25 +16,50 @@ public class UniversidadCerca {
     @Column(length = 120)
     private String ciudad;
 
-    /** Lado inverso: la FK vive en Vivienda. */
-    @OneToMany(mappedBy = "universidadCerca", cascade = CascadeType.ALL, orphanRemoval = true)
+    /** Unidireccional OneToMany. */ 
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "universidad_cerca_id") // crea/usa la FK en la tabla vivienda
     private List<Vivienda> viviendas = new ArrayList<>();
 
     public UniversidadCerca() {}
+
     public UniversidadCerca(String nombre, String ciudad) {
-        this.nombre = nombre; this.ciudad = ciudad;
+        this.nombre = nombre;
+        this.ciudad = ciudad;
     }
 
-    public void addVivienda(Vivienda v){ viviendas.add(v); v.setUniversidadCerca(this); }
-    public void removeVivienda(Vivienda v){ viviendas.remove(v); v.setUniversidadCerca(null); }
+    /** Añade una vivienda a la colección.*/
+    public void addVivienda(Vivienda v) {
+        if (v == null) return;
+        viviendas.add(v);
+    }
 
-    public Long getId() { return id; }
+    /** Remueve una vivienda de la colección.*/
+    public void removeVivienda(Vivienda v) {
+        if (v == null) return;
+        viviendas.remove(v);
+    }
+
+    // Getters / setters
     public String getNombre() { return nombre; }
     public void setNombre(String nombre) { this.nombre = nombre; }
+
     public String getCiudad() { return ciudad; }
     public void setCiudad(String ciudad) { this.ciudad = ciudad; }
-    public List<Vivienda> getViviendas() { return viviendas; }
 
-    @Override public boolean equals(Object o){ return o instanceof UniversidadCerca u && id!=null && id.equals(u.id); }
-    @Override public int hashCode(){ return Objects.hashCode(id); }
+    public List<Vivienda> getViviendas() { return viviendas; }
+    public void setViviendas(List<Vivienda> viviendas) { this.viviendas = viviendas; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UniversidadCerca)) return false;
+        UniversidadCerca that = (UniversidadCerca) o;
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.getId());
+    }
 }


### PR DESCRIPTION

Se corrigen y homogeneizan las entidades:
- Estancia: extiende BaseEntity, mapeos JPA revisados.
- Contrato: extiende BaseEntity, relación OneToOne dueña en Contrato.
- UniversidadCerca: extiende BaseEntity, helpers add/remove y mapeo OneToMany.

Notas:
- Solo se modificaron archivos en co.edu.udistrital.mdp.back.entities.
- Por favor, revisar que no existan conflictos con cambios recientes en develop.
